### PR TITLE
Changed "Intensity" to Brightness >> Better Indicator for Readability

### DIFF
--- a/SOZOChromoplast/SOZOChromoplast.m
+++ b/SOZOChromoplast/SOZOChromoplast.m
@@ -20,7 +20,7 @@
     self = [super init];
     if (self) {
         NSArray *pixelColors = [SOZOBitmapDataGenerator bitmapDataForImage:[image downsizeIfNeeded]];
-        SOZOColorSorter *sorter = [SOZOColorSorter colorSorterWithGranularity:5];
+        SOZOColorSorter *sorter = [SOZOColorSorter colorSorterWithGranularity:2];
         _colors = [sorter sortColors:pixelColors];
         [self setUpColors];
     }
@@ -41,11 +41,11 @@
 }
 
 - (UIColor *)defaultFirstHighlight {
-    return [self.dominantColor intensity] > 1.5 ? [UIColor blackColor] : [UIColor whiteColor];
+    return [self.dominantColor brightness] > 0.5 ? [UIColor blackColor] : [UIColor whiteColor];
 }
 
 - (UIColor *)defaultSecondHighlight {
-    return [self.dominantColor intensity] > 1.5 ? [UIColor darkGrayColor] : [UIColor lightGrayColor];
+    return [self.dominantColor brightness] > 0.5 ? [UIColor darkGrayColor] : [UIColor lightGrayColor];
 }
 
 @end

--- a/SOZOChromoplast/UIColor+SOZOCompatibility.m
+++ b/SOZOChromoplast/UIColor+SOZOCompatibility.m
@@ -1,12 +1,12 @@
 #import "UIColor+SOZOCompatibility.h"
 #import "UIColor+SOZOIntensity.h"
 
-const float kSOZOMinimumIntensityDifference = 1.f;
+const float kSOZOMinimumIntensityDifference = 0.35f;
 
 @implementation UIColor (SOZOCompatibility)
 
 - (BOOL)sozo_isCompatibleWithColor:(UIColor *)color {
-    return fabs([color intensity] - [self intensity]) > kSOZOMinimumIntensityDifference;
+    return fabs([color brightness] - [self brightness]) > kSOZOMinimumIntensityDifference;
 }
 
 @end

--- a/SOZOChromoplast/UIColor+SOZOIntensity.h
+++ b/SOZOChromoplast/UIColor+SOZOIntensity.h
@@ -2,6 +2,6 @@
 
 @interface UIColor (SOZOIntensity)
 
-- (float)intensity;
+- (float)brightness;
 
 @end

--- a/SOZOChromoplast/UIColor+SOZOIntensity.m
+++ b/SOZOChromoplast/UIColor+SOZOIntensity.m
@@ -2,10 +2,10 @@
 
 @implementation UIColor (SOZOIntensity)
 
-- (float)intensity {
-    CGFloat r, g, b;
-    [self getRed:&r green:&g blue:&b alpha:NULL];
-    return r + g + b;
+- (float)brightness {
+    CGFloat brightness;
+    [self getHue:NULL saturation:NULL brightness:&brightness alpha:NULL];
+    return brightness;
 }
 
 @end


### PR DESCRIPTION
If I am correct that the reason the "intensity" calculation was introduced in this framework is to make the colors readable when setting the `dominantColor` as a background color, then here's my two cents:

The important factor for readability is not the "intensity" named value used here which simply consists of a sum of all RGB values. Instead it is the (subjective) brightness difference between two colors which can be quickly calculated like I did in this pull request by using UIColors HSB system instead of the RGB system. One could also calculate it with the RGB values, see formulas [here](http://stackoverflow.com/questions/596216/formula-to-determine-brightness-of-rgb-color).

To learn more about readability and color contrasts please see [this section](http://www.w3.org/TR/AERT#color-contrast) from the W3C accessibility guide. It also includes a description on how and why using the brightness value is the right one for readability.

I have updated all constants (`kSOZOMinimumIntensityDifference` and intensity medium constant) to work with the new brightness calculation. Everything should just work when this pull request gets merged.

What's left:
* One thing I didn't do (I didn't want to make merging complicated) was to rename the class `UIColor+SOZOIntensity`. That could be changed to `UIColor+SOZOBrightness` to clean things up.
* For my purposes a granularity constant set to 2 instead of 5 (like it was before) lead to much better results, so I kept this value in this request. But since I'm not the only one using this framework you could change the constant easily back to 5 if needed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sozorogami/sozochromoplast/2)
<!-- Reviewable:end -->
