### PR TITLE
changing bytesPerPixel from 4 to 6 to avoid crashing on iphone 6+

### DIFF
--- a/SOZOChromoplast/SOZOBitmapDataGenerator.m
+++ b/SOZOChromoplast/SOZOBitmapDataGenerator.m
@@ -37,7 +37,7 @@
         [NSException raise:NSInternalInconsistencyException format:@"Error creating color space."];
     }
 
-    NSInteger bytesPerPixel = 4;
+    NSInteger bytesPerPixel = 6; 
     unsigned long bytesPerRow = size.width * bytesPerPixel;
     unsigned long totalBytes = bytesPerRow * size.height;
 


### PR DESCRIPTION
changing bytesPerPixel from 4 to 6 to avoid crashing on iphone 6+
